### PR TITLE
Fix Stripe webhook body handling

### DIFF
--- a/scripts/test-stripe-webhook.ts
+++ b/scripts/test-stripe-webhook.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env npx tsx
+
+import express from "express";
+import Stripe from "stripe";
+import { once } from "events";
+import type { AddressInfo } from "net";
+
+async function main() {
+  // Provide sensible defaults so the webhook module can be imported in isolation.
+  process.env.STRIPE_SECRET_KEY =
+    process.env.STRIPE_SECRET_KEY ?? "sk_test_dummy_secret";
+  process.env.STRIPE_WEBHOOK_SECRET =
+    process.env.STRIPE_WEBHOOK_SECRET ?? "whsec_dummy_secret";
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? "postgres://user:pass@localhost:5432/postgres";
+
+  const { stripeWebhookRouter } = await import("../server/routes");
+
+  const app = express();
+  app.use(stripeWebhookRouter);
+
+  const server = app.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const payload = JSON.stringify({
+    id: "evt_test_webhook",
+    object: "event",
+    type: "charge.succeeded",
+  });
+
+  const signature = Stripe.webhooks.generateTestHeaderString({
+    payload,
+    secret: process.env.STRIPE_WEBHOOK_SECRET!,
+  });
+
+  const url = `http://127.0.0.1:${port}/api/stripe/webhook`;
+
+  const sendWebhook = async (attempt: number) => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "stripe-signature": signature,
+      },
+      body: payload,
+    });
+
+    console.log(`Attempt ${attempt}: HTTP ${response.status}`);
+
+    if (response.status !== 200) {
+      throw new Error(`Expected HTTP 200 but received ${response.status}`);
+    }
+  };
+
+  await sendWebhook(1);
+  await sendWebhook(2);
+
+  console.log(
+    "Stripe webhook responded with HTTP 200 on the initial delivery and retry."
+  );
+
+  server.close();
+}
+
+main().catch((error) => {
+  console.error("Stripe webhook test failed:", error);
+  process.exitCode = 1;
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,14 @@
 // server/index.ts
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
+import { registerRoutes, stripeWebhookRouter } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import path from "path";
 
 const app = express();
+
+// Stripe webhooks require the raw body to validate signatures.
+// Register the webhook router before the JSON/body-parser middleware runs.
+app.use(stripeWebhookRouter);
 
 app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ extended: false, limit: "50mb" }));

--- a/server/stripe-webhooks.ts
+++ b/server/stripe-webhooks.ts
@@ -13,7 +13,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
 
 const WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
 
-export async function handleStripeWebhook(rawBody: string, signature: string) {
+export async function handleStripeWebhook(rawBody: Buffer | string, signature: string) {
   if (!WEBHOOK_SECRET) {
     throw new Error('STRIPE_WEBHOOK_SECRET not configured');
   }


### PR DESCRIPTION
## Summary
- register the Stripe webhook router before the global body parsers so the raw payload remains available
- pass the raw Buffer to `handleStripeWebhook` for signature verification and guard against missing signatures
- add an automated webhook retry test script that exercises signed payload delivery

## Testing
- `npx tsx scripts/test-stripe-webhook.ts`
- `npm run check` *(fails: pre-existing TypeScript errors in client and server/vite.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a4e1cac832a9a864148294739c8