### PR TITLE
Enforce unique captain profiles and add charter indexes

### DIFF
--- a/migrations/0002_unique_captain_profile.sql
+++ b/migrations/0002_unique_captain_profile.sql
@@ -1,0 +1,13 @@
+-- Ensure only one captain profile exists per user by removing duplicates
+DELETE FROM "captains" c1
+USING "captains" c2
+WHERE c1."user_id" = c2."user_id"
+  AND c1."id" > c2."id";
+
+-- Enforce uniqueness at the database level
+CREATE UNIQUE INDEX IF NOT EXISTS "captains_user_id_unique" ON "captains" USING btree ("user_id");
+
+-- Improve charter search performance
+CREATE INDEX IF NOT EXISTS "idx_charters_location" ON "charters" USING btree ("location");
+CREATE INDEX IF NOT EXISTS "idx_charters_target_species" ON "charters" USING btree ("target_species");
+CREATE INDEX IF NOT EXISTS "idx_charters_is_listed" ON "charters" USING btree ("is_listed");

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1213 @@
+{
+  "id": "badc6098-31d7-4570-8d79-2be81a20960f",
+  "prevId": "f9959829-63b6-46b8-a4b0-86bf2aa84803",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "charter_id": {
+          "name": "charter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "booked_slots": {
+          "name": "booked_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_charter_date": {
+          "name": "idx_availability_charter_date",
+          "columns": [
+            {
+              "expression": "charter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_charter_id_charters_id_fk": {
+          "name": "availability_charter_id_charters_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "charters",
+          "columnsFrom": [
+            "charter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charter_id": {
+          "name": "charter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_date": {
+          "name": "trip_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guests": {
+          "name": "guests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_proof_url": {
+          "name": "payment_proof_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_user_id_users_id_fk": {
+          "name": "bookings_user_id_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_charter_id_charters_id_fk": {
+          "name": "bookings_charter_id_charters_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "charters",
+          "columnsFrom": [
+            "charter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_payment_info": {
+      "name": "captain_payment_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routing_number": {
+          "name": "routing_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_holder_name": {
+          "name": "account_holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paypal_email": {
+          "name": "paypal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venmo_username": {
+          "name": "venmo_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zelle_email": {
+          "name": "zelle_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cashapp_tag": {
+          "name": "cashapp_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_method": {
+          "name": "preferred_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bank'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_payment_info_captain_id_captains_id_fk": {
+          "name": "captain_payment_info_captain_id_captains_id_fk",
+          "tableFrom": "captain_payment_info",
+          "tableTo": "captains",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_payment_info_captain_id_unique": {
+          "name": "captain_payment_info_captain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "captain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captains": {
+      "name": "captains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.00'"
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "license_document": {
+          "name": "license_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_documentation": {
+          "name": "boat_documentation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insurance_document": {
+          "name": "insurance_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identification_photo": {
+          "name": "identification_photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_permit": {
+          "name": "local_permit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpr_certification": {
+          "name": "cpr_certification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_testing_results": {
+          "name": "drug_testing_results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_started_at": {
+          "name": "onboarding_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "captains_user_id_unique": {
+          "name": "captains_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "captains_user_id_users_id_fk": {
+          "name": "captains_user_id_users_id_fk",
+          "tableFrom": "captains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.charters": {
+      "name": "charters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_species": {
+          "name": "target_species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_guests": {
+          "name": "max_guests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boat_specs": {
+          "name": "boat_specs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included": {
+          "name": "included",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_charters_location": {
+          "name": "idx_charters_location",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charters_target_species": {
+          "name": "idx_charters_target_species",
+          "columns": [
+            {
+              "expression": "target_species",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charters_is_listed": {
+          "name": "idx_charters_is_listed",
+          "columns": [
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "charters_captain_id_captains_id_fk": {
+          "name": "charters_captain_id_captains_id_fk",
+          "tableFrom": "charters",
+          "tableTo": "captains",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_unique": {
+          "name": "email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charter_id": {
+          "name": "charter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_receiver_id_users_id_fk": {
+          "name": "messages_receiver_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_charter_id_charters_id_fk": {
+          "name": "messages_charter_id_charters_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "charters",
+          "columnsFrom": [
+            "charter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charter_id": {
+          "name": "charter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reviews_captain_id_captains_id_fk": {
+          "name": "reviews_captain_id_captains_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "captains",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reviews_charter_id_charters_id_fk": {
+          "name": "reviews_charter_id_charters_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "charters",
+          "columnsFrom": [
+            "charter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'captain_monthly'"
+        },
+        "trial_start_date": {
+          "name": "trial_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end_date": {
+          "name": "trial_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1757097299915,
       "tag": "0000_sweet_exodus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758235521735,
+      "tag": "0002_unique_captain_profile",
+      "breakpoints": true
     }
   ]
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1998,17 +1998,60 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (!req.session.userId) {
           return res.status(401).json({ error: "Unauthorized" });
         }
-        const { bio, licenseNumber, location, experience } = req.body ?? {};
+
+        const { bio, licenseNumber, location, experience, firstName, lastName } =
+          req.body ?? {};
+
+        const computedName = `${firstName ?? ""} ${lastName ?? ""}`.trim();
+        const updateData: Partial<typeof captainsTable.$inferInsert> = {};
+
+        if (typeof bio === "string") {
+          updateData.bio = bio;
+        }
+        if (typeof licenseNumber === "string") {
+          updateData.licenseNumber = licenseNumber;
+        }
+        if (typeof location === "string") {
+          updateData.location = location;
+        }
+        if (typeof experience === "string") {
+          updateData.experience = experience;
+        }
+        if (computedName) {
+          updateData.name = computedName;
+        }
+
+        const [existingCaptain] = await db
+          .select({ id: captainsTable.id })
+          .from(captainsTable)
+          .where(eq(captainsTable.userId, req.session.userId));
+
+        if (existingCaptain) {
+          if (Object.keys(updateData).length === 0) {
+            const [current] = await db
+              .select()
+              .from(captainsTable)
+              .where(eq(captainsTable.id, existingCaptain.id));
+            return res.status(200).json(current);
+          }
+
+          const [updated] = await db
+            .update(captainsTable)
+            .set(updateData)
+            .where(eq(captainsTable.userId, req.session.userId))
+            .returning();
+          return res.status(200).json(updated);
+        }
 
         const [created] = await db
           .insert(captainsTable)
           .values({
             userId: req.session.userId,
-            name: `${req.body.firstName || 'Captain'} ${req.body.lastName || ''}`.trim(),
-            bio: bio || '',
-            licenseNumber: licenseNumber || '',
-            location: location || '',
-            experience: experience || '',
+            name: computedName || "Captain",
+            bio: typeof bio === "string" ? bio : "",
+            licenseNumber: typeof licenseNumber === "string" ? licenseNumber : "",
+            location: typeof location === "string" ? location : "",
+            experience: typeof experience === "string" ? experience : "",
             verified: false,
           })
           .returning();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -9,6 +9,7 @@ import {
   varchar,
   jsonb,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -50,52 +51,64 @@ export const users = pgTable("users", {
 // =====================
 // Captains
 // =====================
-export const captains = pgTable("captains", {
-  id: serial("id").primaryKey(),
-  userId: varchar("user_id").references(() => users.id).notNull(),
-  name: text("name").notNull(),
-  bio: text("bio").notNull(),
-  experience: text("experience").notNull(),
-  licenseNumber: text("license_number").notNull(),
-  location: text("location").notNull(),
-  avatar: text("avatar"),
-  verified: boolean("verified").default(false),
-  rating: decimal("rating", { precision: 3, scale: 2 }).default("0.00"),
-  reviewCount: integer("review_count").default(0),
-  // Onboarding fields
-  onboardingCompleted: boolean("onboarding_completed").default(false),
-  licenseDocument: text("license_document"), // Object storage URL
-  boatDocumentation: text("boat_documentation"), // Object storage URL
-  insuranceDocument: text("insurance_document"), // Object storage URL
-  identificationPhoto: text("identification_photo"), // Object storage URL
-  localPermit: text("local_permit"), // Object storage URL
-  cprCertification: text("cpr_certification"), // Object storage URL (optional)
-  drugTestingResults: text("drug_testing_results"), // Object storage URL (optional)
-  onboardingStartedAt: timestamp("onboarding_started_at"),
-  onboardingCompletedAt: timestamp("onboarding_completed_at"),
-});
+export const captains = pgTable(
+  "captains",
+  {
+    id: serial("id").primaryKey(),
+    userId: varchar("user_id").references(() => users.id).notNull(),
+    name: text("name").notNull(),
+    bio: text("bio").notNull(),
+    experience: text("experience").notNull(),
+    licenseNumber: text("license_number").notNull(),
+    location: text("location").notNull(),
+    avatar: text("avatar"),
+    verified: boolean("verified").default(false),
+    rating: decimal("rating", { precision: 3, scale: 2 }).default("0.00"),
+    reviewCount: integer("review_count").default(0),
+    // Onboarding fields
+    onboardingCompleted: boolean("onboarding_completed").default(false),
+    licenseDocument: text("license_document"), // Object storage URL
+    boatDocumentation: text("boat_documentation"), // Object storage URL
+    insuranceDocument: text("insurance_document"), // Object storage URL
+    identificationPhoto: text("identification_photo"), // Object storage URL
+    localPermit: text("local_permit"), // Object storage URL
+    cprCertification: text("cpr_certification"), // Object storage URL (optional)
+    drugTestingResults: text("drug_testing_results"), // Object storage URL (optional)
+    onboardingStartedAt: timestamp("onboarding_started_at"),
+    onboardingCompletedAt: timestamp("onboarding_completed_at"),
+  },
+  (table) => [uniqueIndex("captains_user_id_unique").on(table.userId)]
+);
 
 // =====================
 // Charters
 // =====================
-export const charters = pgTable("charters", {
-  id: serial("id").primaryKey(),
-  captainId: integer("captain_id").references(() => captains.id).notNull(),
-  title: text("title").notNull(),
-  description: text("description").notNull(),
-  location: text("location").notNull(),
-  lat: decimal("lat", { precision: 10, scale: 7 }),
-  lng: decimal("lng", { precision: 10, scale: 7 }),
-  targetSpecies: text("target_species").notNull(),
-  duration: text("duration").notNull(),
-  maxGuests: integer("max_guests").notNull(),
-  price: decimal("price", { precision: 10, scale: 2 }).notNull(),
-  boatSpecs: text("boat_specs"),
-  included: text("included"),
-  images: text("images").array(),
-  available: boolean("available").default(true),
-  isListed: boolean("is_listed").default(true),
-});
+export const charters = pgTable(
+  "charters",
+  {
+    id: serial("id").primaryKey(),
+    captainId: integer("captain_id").references(() => captains.id).notNull(),
+    title: text("title").notNull(),
+    description: text("description").notNull(),
+    location: text("location").notNull(),
+    lat: decimal("lat", { precision: 10, scale: 7 }),
+    lng: decimal("lng", { precision: 10, scale: 7 }),
+    targetSpecies: text("target_species").notNull(),
+    duration: text("duration").notNull(),
+    maxGuests: integer("max_guests").notNull(),
+    price: decimal("price", { precision: 10, scale: 2 }).notNull(),
+    boatSpecs: text("boat_specs"),
+    included: text("included"),
+    images: text("images").array(),
+    available: boolean("available").default(true),
+    isListed: boolean("is_listed").default(true),
+  },
+  (table) => [
+    index("idx_charters_location").on(table.location),
+    index("idx_charters_target_species").on(table.targetSpecies),
+    index("idx_charters_is_listed").on(table.isListed),
+  ]
+);
 
 // =====================
 // Bookings

--- a/test-captain-flow.sh
+++ b/test-captain-flow.sh
@@ -91,17 +91,44 @@ if [ $? -ne 0 ]; then exit 1; fi
 echo "📋 PASO 5: CREAR PERFIL CAPTAIN"
 echo "==============================="
 captain_profile='{
-  "businessName": "Test Charter Co",
-  "description": "Professional test charter service",
+  "firstName": "Captain",
+  "lastName": "Test",
+  "bio": "Professional test charter service",
   "location": "Key West, FL",
-  "yearsExperience": 10,
-  "certifications": ["USCG Master", "CPR Certified"],
-  "insuranceNumber": "TEST123456",
+  "experience": "10 years guiding offshore trips",
   "licenseNumber": "FL123456"
 }'
 
-make_request "POST" "/api/captain/profile" "$captain_profile" "Creando perfil de captain"
+make_request "POST" "/api/captains/onboarding" "$captain_profile" "Creando perfil de captain"
 if [ $? -ne 0 ]; then exit 1; fi
+
+CAPTAIN_ID=$(cat /tmp/last_captain_response.json | jq -r '.id // empty')
+echo "   👤 Perfil de captain ID: $CAPTAIN_ID"
+
+echo "📋 PASO 5B: VALIDAR PERFIL ÚNICO"
+echo "================================"
+captain_profile_update='{
+  "location": "Miami, FL",
+  "experience": "Actualización automática de experiencia"
+}'
+
+make_request "POST" "/api/captains/onboarding" "$captain_profile_update" "Actualizando perfil existente"
+if [ $? -ne 0 ]; then exit 1; fi
+
+UPDATED_CAPTAIN_ID=$(cat /tmp/last_captain_response.json | jq -r '.id // empty')
+UPDATED_LOCATION=$(cat /tmp/last_captain_response.json | jq -r '.location // empty')
+
+if [ "$UPDATED_CAPTAIN_ID" != "$CAPTAIN_ID" ]; then
+    echo "   ❌ Se creó un segundo perfil de captain"
+    exit 1
+fi
+
+if [ "$UPDATED_LOCATION" != "Miami, FL" ]; then
+    echo "   ❌ No se actualizó la ubicación del perfil"
+    exit 1
+fi
+
+echo "   ✅ Perfil existente actualizado sin duplicados"
 
 echo "📋 PASO 6: VERIFICAR DOCUMENTOS REQUERIDOS"
 echo "=========================================="


### PR DESCRIPTION
## Summary
- add a database-level unique index on captain user IDs and supporting migration cleanup
- index frequently filtered charter fields to improve query performance
- update the captain onboarding route and test flow to respect the single-profile constraint

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a776140832a9c0c0e2360299a48