### PR TITLE
Refactor captain subscription handlers

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,6 +38,11 @@ import { and, eq, ilike, inArray, gte, lt, or, isNotNull, desc, sql } from "driz
 import { sendEmailVerification, sendWelcomeEmail, generateVerificationToken , sendEmail  , } from "./emailService";
 import { ObjectStorageService, ObjectNotFoundError } from "./objectStorage";
 import { handleStripeWebhook } from "./stripe-webhooks";
+import {
+  makeCancelCaptainSubscriptionHandler,
+  makeCreateCaptainSubscriptionHandler,
+  makeGetCaptainSubscriptionHandler,
+} from "./stripe-subscription-handlers";
 import * as schema from "../shared/schema";
 
 /**
@@ -2431,190 +2436,34 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // STRIPE SUBSCRIPTION ENDPOINTS  
   // ==============================
 
-  // Create subscription for captain
-  app.post("/api/captain/subscribe", async (req: Request, res: Response) => {
-    try {
-      if (!req.session.userId) {
-        return res.status(401).json({ error: "Unauthorized" });
-      }
-      
-      if (!process.env.STRIPE_SECRET_KEY) {
-        return res.status(503).json({ error: 'Stripe not configured' });
-      }
-      
-      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-        apiVersion: "2025-08-27.basil",
-      });
-      
-      const [user] = await db
-        .select()
-        .from(usersTable)
-        .where(eq(usersTable.id, req.session.userId));
+  const stripeFactory = () =>
+    new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2025-08-27.basil",
+    });
 
-      if (!user) {
-        return res.status(404).json({ error: "User not found" });
-      }
+  app.post(
+    "/api/captain/subscribe",
+    makeCreateCaptainSubscriptionHandler({
+      db,
+      stripeFactory,
+    }),
+  );
 
-      // Check if user already has an active subscription
-      if (user.stripeSubscriptionId) {
-        const { data: subscription } = await stripe.subscriptions.retrieve(user.stripeSubscriptionId) as any;
-        
-        if (subscription.status === 'active' || subscription.status === 'trialing') {
-          return res.json({
-            subscription: {
-              id: subscription.id,
-              status: subscription.status,
-              current_period_end: subscription.current_period_end,
-            }
-          });
-        }
-      }
+  app.get(
+    "/api/captain/subscription",
+    makeGetCaptainSubscriptionHandler({
+      db,
+      stripeFactory,
+    }),
+  );
 
-      // Create or get Stripe customer
-      let customer;
-      if (user.stripeCustomerId) {
-        customer = await stripe.customers.retrieve(user.stripeCustomerId);
-      } else {
-        customer = await stripe.customers.create({
-          email: user.email || "",
-          name: [user.firstName, user.lastName].filter(Boolean).join(" ") || undefined,
-        });
-
-        // Update user with customer ID
-        await db
-          .update(usersTable)
-          .set({ stripeCustomerId: customer.id })
-          .where(eq(usersTable.id, user.id));
-      }
-
-      // Create subscription with 1-month trial
-      const subscription = await stripe.subscriptions.create({
-        customer: customer.id,
-        items: [{
-          price_data: {
-            currency: 'usd',
-            unit_amount: 4900,
-            recurring: {
-              interval: 'month',
-            },
-            product_data: {
-              name: 'Captain Subscription',
-              description: 'Professional charter captain subscription with full platform access',
-            },
-          } as any,
-        }],
-        trial_period_days: 30,
-      });
-
-      // Update user with subscription ID
-      await db
-        .update(usersTable)
-        .set({ stripeSubscriptionId: subscription.id })
-        .where(eq(usersTable.id, user.id));
-
-      res.json({
-        subscriptionId: subscription.id,
-        clientSecret: null, // No payment intent needed for trial
-        status: subscription.status,
-        trial_end: subscription.trial_end,
-      });
-
-    } catch (error: any) {
-      console.error("Subscription creation error:", error);
-      res.status(500).json({ error: "Failed to create subscription: " + error.message });
-    }
-  });
-
-  // Get subscription status
-  app.get("/api/captain/subscription", async (req: Request, res: Response) => {
-    try {
-      if (!req.session.userId) {
-        return res.status(401).json({ error: "Unauthorized" });
-      }
-      
-      if (!process.env.STRIPE_SECRET_KEY) {
-        return res.status(503).json({ error: 'Stripe not configured' });
-      }
-      
-      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-        apiVersion: "2025-08-27.basil",
-      });
-
-      const [user] = await db
-        .select()
-        .from(usersTable)
-        .where(eq(usersTable.id, req.session.userId));
-
-      if (!user || !user.stripeSubscriptionId) {
-        return res.json({ subscription: null });
-      }
-
-      const { data: subscription } = await stripe.subscriptions.retrieve(user.stripeSubscriptionId) as any;
-
-      res.json({
-        subscription: {
-          id: subscription.id,
-          status: subscription.status,
-          current_period_end: subscription.current_period_end,
-          trial_end: subscription.trial_end,
-          cancel_at_period_end: subscription.cancel_at_period_end,
-        }
-      });
-
-    } catch (error: any) {
-      console.error("Get subscription error:", error);
-      res.status(500).json({ error: "Failed to get subscription" });
-    }
-  });
-
-  // Cancel subscription
-  app.post("/api/captain/subscription/cancel", async (req: Request, res: Response) => {
-    try {
-      if (!req.session.userId) {
-        return res.status(401).json({ error: "Unauthorized" });
-      }
-      
-      // Verificar si es un capitán
-      const captain = await db.select().from(captainsTable).where(eq(captainsTable.userId, req.session.userId)).execute();
-      if (!captain.length) {
-        return res.status(403).json({ error: 'Only captains can cancel subscription' });
-      }
-
-      if (!process.env.STRIPE_SECRET_KEY) {
-        return res.status(503).json({ error: 'Stripe not configured' });
-      }
-      
-      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-        apiVersion: "2025-08-27.basil",
-      });
-
-      const [user] = await db
-        .select()
-        .from(usersTable)
-        .where(eq(usersTable.id, req.session.userId));
-
-      if (!user || !user.stripeSubscriptionId) {
-        return res.status(404).json({ error: "No subscription found" });
-      }
-
-      const { data: subscription } = await stripe.subscriptions.update(user.stripeSubscriptionId, {
-        cancel_at_period_end: true,
-      }) as any;
-
-      res.json({
-        subscription: {
-          id: subscription.id,
-          status: subscription.status,
-          cancel_at_period_end: subscription.cancel_at_period_end,
-          current_period_end: subscription.current_period_end,
-        }
-      });
-
-    } catch (error: any) {
-      console.error("Cancel subscription error:", error);
-      res.status(500).json({ error: "Failed to cancel subscription" });
-    }
-  });
+  app.post(
+    "/api/captain/subscription/cancel",
+    makeCancelCaptainSubscriptionHandler({
+      db,
+      stripeFactory,
+    }),
+  );
 
   // ============ Stripe Webhooks ============
   app.post('/api/stripe/webhook', express.raw({type: 'application/json'}), async (req: Request, res: Response) => {

--- a/server/stripe-subscription-handlers.ts
+++ b/server/stripe-subscription-handlers.ts
@@ -1,0 +1,228 @@
+import type { Request, Response } from "express";
+import type Stripe from "stripe";
+import { eq } from "drizzle-orm";
+import { captains as captainsTable, users as usersTable } from "@shared/schema";
+
+type RealDb = typeof import("./db")["db"];
+type DbClient = Pick<RealDb, "select" | "update">;
+
+type StripeFactory = () => Stripe;
+
+interface SubscriptionHandlerDeps {
+  db: DbClient;
+  stripeFactory: StripeFactory;
+}
+
+function normalizeSubscription(subscription: Stripe.Subscription) {
+  const subscriptionWithLegacyFields = subscription as Stripe.Subscription & {
+    current_period_end?: number | null;
+  };
+  const firstItem = subscription.items?.data?.[0] as
+    | (Stripe.SubscriptionItem & { current_period_end?: number | null })
+    | undefined;
+  const currentPeriodEnd =
+    subscriptionWithLegacyFields.current_period_end ??
+    firstItem?.current_period_end ??
+    null;
+
+  return {
+    id: subscription.id,
+    status: subscription.status,
+    current_period_end: currentPeriodEnd,
+    trial_end: subscription.trial_end,
+    cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+  };
+}
+
+export function makeCreateCaptainSubscriptionHandler({
+  db,
+  stripeFactory,
+}: SubscriptionHandlerDeps) {
+  return async function createCaptainSubscription(
+    req: Request,
+    res: Response,
+  ) {
+    try {
+      if (!req.session?.userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      if (!process.env.STRIPE_SECRET_KEY) {
+        return res.status(503).json({ error: "Stripe not configured" });
+      }
+
+      const stripe = stripeFactory();
+
+      const [user] = await db
+        .select()
+        .from(usersTable)
+        .where(eq(usersTable.id, req.session.userId));
+
+      if (!user) {
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      if (user.stripeSubscriptionId) {
+        const subscription = await stripe.subscriptions.retrieve(
+          user.stripeSubscriptionId,
+        );
+
+        if (subscription.status === "active" || subscription.status === "trialing") {
+          return res.json({
+            subscription: normalizeSubscription(subscription),
+            clientSecret: null,
+          });
+        }
+      }
+
+      let customer;
+      if (user.stripeCustomerId) {
+        customer = await stripe.customers.retrieve(user.stripeCustomerId);
+      } else {
+        customer = await stripe.customers.create({
+          email: user.email || "",
+          name:
+            [user.firstName, user.lastName].filter(Boolean).join(" ") ||
+            undefined,
+        });
+
+        await db
+          .update(usersTable)
+          .set({ stripeCustomerId: customer.id })
+          .where(eq(usersTable.id, user.id));
+      }
+
+      const subscription = await stripe.subscriptions.create({
+        customer: customer.id,
+        items: [
+          {
+            price_data: {
+              currency: "usd",
+              unit_amount: 4900,
+              recurring: {
+                interval: "month",
+              },
+              product_data: {
+                name: "Captain Subscription",
+                description:
+                  "Professional charter captain subscription with full platform access",
+              },
+            } as any,
+          },
+        ],
+        trial_period_days: 30,
+      });
+
+      await db
+        .update(usersTable)
+        .set({ stripeSubscriptionId: subscription.id })
+        .where(eq(usersTable.id, user.id));
+
+      return res.json({
+        subscription: normalizeSubscription(subscription),
+        clientSecret: null,
+      });
+    } catch (error: any) {
+      console.error("Subscription creation error:", error);
+      return res
+        .status(500)
+        .json({ error: "Failed to create subscription: " + error.message });
+    }
+  };
+}
+
+export function makeGetCaptainSubscriptionHandler({
+  db,
+  stripeFactory,
+}: SubscriptionHandlerDeps) {
+  return async function getCaptainSubscription(req: Request, res: Response) {
+    try {
+      if (!req.session?.userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      if (!process.env.STRIPE_SECRET_KEY) {
+        return res.status(503).json({ error: "Stripe not configured" });
+      }
+
+      const stripe = stripeFactory();
+
+      const [user] = await db
+        .select()
+        .from(usersTable)
+        .where(eq(usersTable.id, req.session.userId));
+
+      if (!user || !user.stripeSubscriptionId) {
+        return res.json({ subscription: null });
+      }
+
+      const subscription = await stripe.subscriptions.retrieve(
+        user.stripeSubscriptionId,
+      );
+
+      return res.json({
+        subscription: normalizeSubscription(subscription),
+      });
+    } catch (error) {
+      console.error("Get subscription error:", error);
+      return res.status(500).json({ error: "Failed to get subscription" });
+    }
+  };
+}
+
+export function makeCancelCaptainSubscriptionHandler({
+  db,
+  stripeFactory,
+}: SubscriptionHandlerDeps) {
+  return async function cancelCaptainSubscription(
+    req: Request,
+    res: Response,
+  ) {
+    try {
+      if (!req.session?.userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      const captain = await db
+        .select()
+        .from(captainsTable)
+        .where(eq(captainsTable.userId, req.session.userId))
+        .execute();
+
+      if (!captain.length) {
+        return res
+          .status(403)
+          .json({ error: "Only captains can cancel subscription" });
+      }
+
+      if (!process.env.STRIPE_SECRET_KEY) {
+        return res.status(503).json({ error: "Stripe not configured" });
+      }
+
+      const stripe = stripeFactory();
+
+      const [user] = await db
+        .select()
+        .from(usersTable)
+        .where(eq(usersTable.id, req.session.userId));
+
+      if (!user || !user.stripeSubscriptionId) {
+        return res.status(404).json({ error: "No subscription found" });
+      }
+
+      const subscription = await stripe.subscriptions.update(
+        user.stripeSubscriptionId,
+        {
+          cancel_at_period_end: true,
+        },
+      );
+
+      return res.json({
+        subscription: normalizeSubscription(subscription),
+      });
+    } catch (error) {
+      console.error("Cancel subscription error:", error);
+      return res.status(500).json({ error: "Failed to cancel subscription" });
+    }
+  };
+}

--- a/tests/stripe-subscription-handlers.test.ts
+++ b/tests/stripe-subscription-handlers.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import type { Request, Response } from "express";
+import {
+  makeCancelCaptainSubscriptionHandler,
+  makeCreateCaptainSubscriptionHandler,
+  makeGetCaptainSubscriptionHandler,
+} from "../server/stripe-subscription-handlers";
+import { captains as captainsTable, users as usersTable } from "@shared/schema";
+
+type CaptainRecord = {
+  userId: string;
+};
+
+type UserRecord = {
+  id: string;
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+};
+
+class FakeDb {
+  public user: UserRecord;
+  private readonly captains: CaptainRecord[];
+
+  constructor(user: UserRecord, captains: CaptainRecord[]) {
+    this.user = { ...user };
+    this.captains = [...captains];
+  }
+
+  select() {
+    return {
+      from: (table: unknown) => {
+        if (table === usersTable) {
+          return {
+            where: async () => [{ ...this.user }],
+          };
+        }
+
+        if (table === captainsTable) {
+          return {
+            where: () => ({
+              execute: async () =>
+                this.captains.filter((captain) => captain.userId === this.user.id),
+            }),
+          };
+        }
+
+        return {
+          where: async () => [],
+        };
+      },
+    };
+  }
+
+  update(table: unknown) {
+    return {
+      set: (values: Partial<UserRecord>) => ({
+        where: async () => {
+          if (table === usersTable) {
+            this.user = { ...this.user, ...values };
+          }
+        },
+      }),
+    };
+  }
+}
+
+type SubscriptionRecord = {
+  id: string;
+  status: string;
+  current_period_end: number;
+  trial_end: number | null;
+  cancel_at_period_end: boolean;
+};
+
+class FakeStripe {
+  private customerCounter = 0;
+  private subscriptionCounter = 0;
+  private readonly customerStore = new Map<string, { id: string; email?: string; name?: string }>();
+  private readonly subscriptionStore = new Map<string, SubscriptionRecord>();
+
+  customers = {
+    retrieve: async (id: string) => {
+      const customer = this.customerStore.get(id);
+      if (!customer) {
+        throw new Error(`Customer ${id} not found`);
+      }
+      return customer;
+    },
+    create: async ({ email, name }: { email?: string; name?: string }) => {
+      const id = `cus_${++this.customerCounter}`;
+      const customer = { id, email, name };
+      this.customerStore.set(id, customer);
+      return customer;
+    },
+  };
+
+  subscriptions = {
+    retrieve: async (id: string) => {
+      const subscription = this.subscriptionStore.get(id);
+      if (!subscription) {
+        throw new Error(`Subscription ${id} not found`);
+      }
+      return subscription;
+    },
+    create: async ({ customer }: { customer: string }) => {
+      const id = `sub_${++this.subscriptionCounter}`;
+      const now = Math.floor(Date.now() / 1000);
+      const subscription: SubscriptionRecord = {
+        id,
+        status: "trialing",
+        current_period_end: now + 60 * 60 * 24 * 30,
+        trial_end: now + 60 * 60 * 24 * 30,
+        cancel_at_period_end: false,
+      };
+      this.subscriptionStore.set(id, subscription);
+      return subscription;
+    },
+    update: async (
+      id: string,
+      { cancel_at_period_end }: { cancel_at_period_end?: boolean },
+    ) => {
+      const subscription = this.subscriptionStore.get(id);
+      if (!subscription) {
+        throw new Error(`Subscription ${id} not found`);
+      }
+      if (typeof cancel_at_period_end === "boolean") {
+        subscription.cancel_at_period_end = cancel_at_period_end;
+      }
+      this.subscriptionStore.set(id, subscription);
+      return subscription;
+    },
+  };
+}
+
+function createRequest(): Request {
+  return {
+    session: {
+      userId: "user-1",
+    },
+  } as unknown as Request;
+}
+
+class MockResponse {
+  statusCode = 200;
+  body: unknown;
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(payload: unknown) {
+    this.body = payload;
+    return this;
+  }
+}
+
+async function run() {
+  process.env.STRIPE_SECRET_KEY = "sk_test_fake";
+
+  const db = new FakeDb(
+    {
+      id: "user-1",
+      email: "captain@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+    },
+    [{ userId: "user-1" }],
+  );
+
+  const stripe = new FakeStripe();
+  const stripeFactory = () => stripe;
+
+  const createHandler = makeCreateCaptainSubscriptionHandler({
+    db: db as unknown as any,
+    stripeFactory,
+  });
+
+  const getHandler = makeGetCaptainSubscriptionHandler({
+    db: db as unknown as any,
+    stripeFactory,
+  });
+
+  const cancelHandler = makeCancelCaptainSubscriptionHandler({
+    db: db as unknown as any,
+    stripeFactory,
+  });
+
+  const createRes = new MockResponse();
+  await createHandler(createRequest(), createRes as unknown as Response);
+  assert.equal(createRes.statusCode, 200);
+  const created = createRes.body as {
+    subscription: SubscriptionRecord;
+    clientSecret: null;
+  };
+  assert.ok(created.subscription.id);
+  assert.equal(db.user.stripeSubscriptionId, created.subscription.id);
+  assert.equal(db.user.stripeCustomerId?.startsWith("cus_"), true);
+
+  const getRes = new MockResponse();
+  await getHandler(createRequest(), getRes as unknown as Response);
+  assert.equal(getRes.statusCode, 200);
+  const retrieved = getRes.body as { subscription: SubscriptionRecord | null };
+  assert.ok(retrieved.subscription);
+  assert.equal(retrieved.subscription?.id, created.subscription.id);
+
+  const cancelRes = new MockResponse();
+  await cancelHandler(createRequest(), cancelRes as unknown as Response);
+  assert.equal(cancelRes.statusCode, 200);
+  const cancelled = cancelRes.body as { subscription: SubscriptionRecord };
+  assert.equal(cancelled.subscription.cancel_at_period_end, true);
+
+  console.log(
+    "Stripe subscription handlers create/retrieve/cancel flows completed without throwing.",
+  );
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- extract the captain subscription endpoints into dedicated handlers that work with the Stripe API responses directly and normalize their JSON payloads
- update the route registrations to use the new handlers and a shared Stripe factory instead of destructuring `data`
- add a TypeScript test harness with fake Stripe and database adapters to exercise the create, retrieve, and cancel flows

## Testing
- npx tsx tests/stripe-subscription-handlers.test.ts
- npm run check *(fails: existing frontend type mismatches in search and map components)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a4ebfa4832a8500cea0f4eb6dff