### PR TITLE
Implement availability locking for bookings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test:concurrency": "tsx scripts/test-concurrent-bookings.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.17.1",

--- a/scripts/test-concurrent-bookings.ts
+++ b/scripts/test-concurrent-bookings.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+
+import { db, pool } from "../server/db";
+import { storage } from "../server/storage";
+import {
+  availability,
+  bookings,
+  captains,
+  charters,
+  users,
+} from "../shared/schema";
+
+async function main() {
+  const uniqueSuffix = randomUUID().slice(0, 8);
+  const bookingDate = new Date();
+  bookingDate.setUTCHours(0, 0, 0, 0);
+
+  let userId: string | null = null;
+  let captainUserId: string | null = null;
+  let captainId: number | null = null;
+  let charterId: number | null = null;
+  let availabilityId: number | null = null;
+
+  try {
+    const [user] = await db
+      .insert(users)
+      .values({
+        id: `user_${uniqueSuffix}`,
+        email: `user_${uniqueSuffix}@example.com`,
+        firstName: "Concurrency",
+        lastName: "Tester",
+        role: "user",
+        password: "test",
+      })
+      .returning();
+    userId = user.id;
+
+    const [captainUser] = await db
+      .insert(users)
+      .values({
+        id: `captain_${uniqueSuffix}`,
+        email: `captain_${uniqueSuffix}@example.com`,
+        firstName: "Captain",
+        lastName: "Concurrent",
+        role: "captain",
+        password: "test",
+      })
+      .returning();
+    captainUserId = captainUser.id;
+
+    const [captain] = await db
+      .insert(captains)
+      .values({
+        userId: captainUser.id,
+        name: "Captain Concurrent",
+        bio: "Testing concurrency handling.",
+        experience: "Seasoned captain",
+        licenseNumber: `LIC-${uniqueSuffix}`,
+        location: "Test Harbor",
+        verified: true,
+      })
+      .returning();
+    captainId = captain.id;
+
+    const [charter] = await db
+      .insert(charters)
+      .values({
+        captainId: captain.id,
+        title: "Concurrency Charter",
+        description: "Charter used to test concurrent bookings.",
+        location: "Test Harbor",
+        targetSpecies: "Test Fish",
+        duration: "4 hours",
+        maxGuests: 6,
+        price: "200.00",
+        boatSpecs: "Fast test boat",
+        included: "All equipment",
+        images: [],
+        available: true,
+        isListed: true,
+      })
+      .returning();
+    charterId = charter.id;
+
+    const [slot] = await db
+      .insert(availability)
+      .values({
+        charterId: charter.id,
+        date: bookingDate,
+        slots: 1,
+        bookedSlots: 0,
+      })
+      .returning();
+    availabilityId = slot.id;
+
+    async function attemptBooking(label: string) {
+      return await db.transaction(async (tx) => {
+        const available = await storage.checkAvailability(
+          charter.id,
+          bookingDate,
+          1,
+          tx,
+        );
+
+        if (!available) {
+          throw new Error(`${label}: slot unavailable`);
+        }
+
+        const [created] = await tx
+          .insert(bookings)
+          .values({
+            userId: user.id,
+            charterId: charter.id,
+            tripDate: bookingDate,
+            guests: 2,
+            totalPrice: "200.00",
+            status: "pending",
+            message: `${label} booking`,
+          })
+          .returning({ id: bookings.id });
+
+        const updated = await storage.updateAvailabilitySlots(
+          charter.id,
+          bookingDate,
+          1,
+          tx,
+        );
+
+        if (!updated) {
+          throw new Error(`${label}: failed to decrement availability`);
+        }
+
+        return created.id;
+      });
+    }
+
+    const [firstResult, secondResult] = await Promise.allSettled([
+      attemptBooking("First"),
+      attemptBooking("Second"),
+    ]);
+
+    const formatResult = (
+      label: string,
+      result: PromiseSettledResult<number>,
+    ) => {
+      if (result.status === "fulfilled") {
+        console.log(`${label} booking succeeded with id ${result.value}`);
+      } else {
+        const reason =
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason);
+        console.log(`${label} booking failed -> ${reason}`);
+      }
+    };
+
+    console.log("=== Concurrent booking test ===");
+    formatResult("First", firstResult);
+    formatResult("Second", secondResult);
+
+    const [remainingAvailability] = await db
+      .select({
+        slots: availability.slots,
+        bookedSlots: availability.bookedSlots,
+      })
+      .from(availability)
+      .where(eq(availability.id, slot.id));
+
+    console.log("Availability after attempts:", remainingAvailability);
+
+    const resultingBookings = await db
+      .select({ id: bookings.id, status: bookings.status })
+      .from(bookings)
+      .where(eq(bookings.charterId, charter.id));
+
+    console.log(
+      `Total bookings stored for charter: ${resultingBookings.length}`,
+    );
+    console.log("Stored bookings:", resultingBookings);
+  } finally {
+    try {
+      if (charterId !== null) {
+        await db.delete(bookings).where(eq(bookings.charterId, charterId));
+      }
+      if (availabilityId !== null) {
+        await db.delete(availability).where(eq(availability.id, availabilityId));
+      }
+      if (charterId !== null) {
+        await db.delete(charters).where(eq(charters.id, charterId));
+      }
+      if (captainId !== null) {
+        await db.delete(captains).where(eq(captains.id, captainId));
+      }
+      if (captainUserId) {
+        await db.delete(users).where(eq(users.id, captainUserId));
+      }
+      if (userId) {
+        await db.delete(users).where(eq(users.id, userId));
+      }
+    } catch (cleanupError) {
+      console.error("Cleanup error:", cleanupError);
+    }
+
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Concurrency test failed", err);
+  process.exit(1);
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2040,6 +2040,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
     // Crea una reserva (usa el usuario en sesión)
     app.post("/api/bookings", async (req: Request, res: Response) => {
+      const SLOTS_PER_BOOKING = 1;
+      const AVAILABILITY_NOT_FOUND = "AVAILABILITY_NOT_FOUND";
+      const AVAILABILITY_UPDATE_FAILED = "AVAILABILITY_UPDATE_FAILED";
+
       try {
         if (!req.session.userId) {
           return res.status(401).json({ message: "Unauthorized" });
@@ -2108,21 +2112,62 @@ export async function registerRoutes(app: Express): Promise<Server> {
         // Future enhancement: add guest-based pricing, date-based pricing, etc.
         const totalPrice = charterPriceDecimal;
 
-        const [created] = await db
-          .insert(bookingsTable)
-          .values({
-            userId: req.session.userId,
-            charterId: charterId,
-            tripDate: new Date(tripDate),
-            guests: Number(guests),
-            totalPrice: totalPrice.toString(),
-            status: "pending",
-            message: message ?? null,
-          })
-          .returning();
+        const tripDateValue =
+          tripDate instanceof Date ? tripDate : new Date(tripDate);
+
+        if (Number.isNaN(tripDateValue.getTime())) {
+          return res.status(400).json({ message: "Invalid trip date" });
+        }
+
+        const created = await db.transaction(async (tx) => {
+          const available = await storage.checkAvailability(
+            charterId,
+            tripDateValue,
+            SLOTS_PER_BOOKING,
+            tx,
+          );
+
+          if (!available) {
+            throw new Error(AVAILABILITY_NOT_FOUND);
+          }
+
+          const [insertedBooking] = await tx
+            .insert(bookingsTable)
+            .values({
+              userId: req.session.userId!,
+              charterId: charterId,
+              tripDate: tripDateValue,
+              guests: Number(guests),
+              totalPrice: totalPrice.toString(),
+              status: "pending",
+              message: message ?? null,
+            })
+            .returning();
+
+          const updated = await storage.updateAvailabilitySlots(
+            charterId,
+            tripDateValue,
+            SLOTS_PER_BOOKING,
+            tx,
+          );
+
+          if (!updated) {
+            throw new Error(AVAILABILITY_UPDATE_FAILED);
+          }
+
+          return insertedBooking;
+        });
 
         return res.status(201).json(serializeBooking(created));
       } catch (error) {
+        if (error instanceof Error) {
+          if (error.message === AVAILABILITY_NOT_FOUND) {
+            return res.status(409).json({ message: "Selected date is no longer available" });
+          }
+          if (error.message === AVAILABILITY_UPDATE_FAILED) {
+            return res.status(409).json({ message: "Unable to reserve the selected slot" });
+          }
+        }
         console.error("Create booking error:", error);
         return res.status(500).json({ message: "Failed to create booking" });
       }


### PR DESCRIPTION
## Summary
- implement availability locking helpers in `DatabaseStorage` to select and update slots with row-level locks
- wrap booking creation in a transaction that checks and decrements availability via the storage helpers
- add a concurrency test script plus npm script to demonstrate competing bookings can’t both consume the same slot

## Testing
- `npm run check` *(fails: existing TypeScript errors in client and server/vite.ts)*
- `npm run test:concurrency` *(fails: DATABASE_URL not set in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a586530832a980db89d7096636d