### PR TITLE
Secure captain document workflow

### DIFF
--- a/migrations/0002_add_captain_document_reviews.sql
+++ b/migrations/0002_add_captain_document_reviews.sql
@@ -1,0 +1,14 @@
+-- Create table to track document review status and approvals
+CREATE TABLE IF NOT EXISTS "captain_document_reviews" (
+  "id" serial PRIMARY KEY,
+  "captain_id" integer NOT NULL REFERENCES "captains"("id") ON DELETE CASCADE,
+  "document_type" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "reviewed_by" varchar REFERENCES "users"("id"),
+  "reviewed_at" timestamp,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "updated_at" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_captain_document_reviews_unique"
+  ON "captain_document_reviews" ("captain_id", "document_type");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1757097299915,
       "tag": "0000_sweet_exodus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1757097299916,
+      "tag": "0001_add_captain_name",
+      "breakpoints": false
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1757097299917,
+      "tag": "0002_add_captain_document_reviews",
+      "breakpoints": false
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -9,6 +9,7 @@ import {
   varchar,
   jsonb,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -74,6 +75,29 @@ export const captains = pgTable("captains", {
   onboardingStartedAt: timestamp("onboarding_started_at"),
   onboardingCompletedAt: timestamp("onboarding_completed_at"),
 });
+
+// =====================
+// Captain Document Reviews
+// =====================
+export const captainDocumentReviews = pgTable(
+  "captain_document_reviews",
+  {
+    id: serial("id").primaryKey(),
+    captainId: integer("captain_id").references(() => captains.id).notNull(),
+    documentType: text("document_type").notNull(),
+    status: text("status").notNull().default("pending"),
+    reviewedBy: varchar("reviewed_by").references(() => users.id),
+    reviewedAt: timestamp("reviewed_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_captain_document_reviews_unique").on(
+      table.captainId,
+      table.documentType,
+    ),
+  ]
+);
 
 // =====================
 // Charters
@@ -267,6 +291,12 @@ export const insertCaptainPaymentInfoSchema = createInsertSchema(captainPaymentI
   updatedAt: true,
 });
 
+export const insertCaptainDocumentReviewSchema = createInsertSchema(captainDocumentReviews).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
 // =====================
 // Types
 // =====================
@@ -280,6 +310,7 @@ export type Availability = typeof availability.$inferSelect;
 export type Subscription = typeof subscriptions.$inferSelect;
 export type EmailVerificationToken = typeof emailVerificationTokens.$inferSelect;
 export type CaptainPaymentInfo = typeof captainPaymentInfo.$inferSelect;
+export type CaptainDocumentReview = typeof captainDocumentReviews.$inferSelect;
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type UpsertUser = typeof users.$inferInsert;
@@ -292,6 +323,7 @@ export type InsertAvailability = z.infer<typeof insertAvailabilitySchema>;
 export type InsertSubscription = z.infer<typeof insertSubscriptionSchema>;
 export type InsertEmailVerificationToken = z.infer<typeof insertEmailVerificationTokenSchema>;
 export type InsertCaptainPaymentInfo = z.infer<typeof insertCaptainPaymentInfoSchema>;
+export type InsertCaptainDocumentReview = z.infer<typeof insertCaptainDocumentReviewSchema>;
 
 // Extended types for API responses
 export type CharterWithCaptain = Charter & {


### PR DESCRIPTION
## Summary
- gate captain document operations behind a shared list of allowed document identifiers and block profile updates that attempt to edit document URLs directly
- require uploaded object identifiers to resolve inside object storage before saving, ensure the caller owns the file, and reset the document’s review state to pending
- add a captain_document_reviews table plus admin APIs so review decisions (with reviewer identity and status) are stored and surfaced in both captain and admin responses

## Testing
- `npm run check` *(fails: existing TypeScript issues in client search components and server/vite.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a5954ac832a8c3be13d9a6c036f