### PR TITLE
Restrict charter access to active subscriptions

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,6 +38,12 @@ import { and, eq, ilike, inArray, gte, lt, or, isNotNull, desc, sql } from "driz
 import { sendEmailVerification, sendWelcomeEmail, generateVerificationToken , sendEmail  , } from "./emailService";
 import { ObjectStorageService, ObjectNotFoundError } from "./objectStorage";
 import { handleStripeWebhook } from "./stripe-webhooks";
+import { scheduleSubscriptionMaintenance } from "./subscriptionMaintenance";
+import {
+  ACTIVE_SUBSCRIPTION_STATUSES,
+  PENDING_SUBSCRIPTION_GRACE_PERIOD_MS,
+  isActiveSubscriptionStatus,
+} from "./subscriptionUtils";
 import * as schema from "../shared/schema";
 
 /**
@@ -909,6 +915,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const whereCond = andAll([
         eq(chartersTable.isListed, true),
+        inArray(subscriptionsTable.status, Array.from(ACTIVE_SUBSCRIPTION_STATUSES)),
         location && String(location).trim() !== ""
           ? ilike(chartersTable.location, `%${String(location)}%`)
           : undefined,
@@ -958,7 +965,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           u_lastName: usersTable.lastName,
         })
         .from(chartersTable)
-        .leftJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(subscriptionsTable, eq(captainsTable.userId, subscriptionsTable.userId))
         .leftJoin(usersTable, eq(captainsTable.userId, usersTable.id));
 
       const rows = whereCond 
@@ -1043,9 +1051,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
           u_lastName: usersTable.lastName,
         })
         .from(chartersTable)
-        .leftJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(subscriptionsTable, eq(captainsTable.userId, subscriptionsTable.userId))
         .leftJoin(usersTable, eq(captainsTable.userId, usersTable.id))
-        .where(eq(chartersTable.isListed, true))
+        .where(
+          and(
+            eq(chartersTable.isListed, true),
+            inArray(subscriptionsTable.status, Array.from(ACTIVE_SUBSCRIPTION_STATUSES)),
+          ),
+        )
         .limit(6);
 
       const result = rows.map((r) => ({
@@ -1131,9 +1145,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
           u_lastName: usersTable.lastName,
         })
         .from(chartersTable)
-        .leftJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(captainsTable, eq(chartersTable.captainId, captainsTable.id))
+        .innerJoin(subscriptionsTable, eq(captainsTable.userId, subscriptionsTable.userId))
         .leftJoin(usersTable, eq(captainsTable.userId, usersTable.id))
-        .where(eq(chartersTable.id, id));
+        .where(
+          and(
+            eq(chartersTable.id, id),
+            eq(chartersTable.isListed, true),
+            inArray(subscriptionsTable.status, Array.from(ACTIVE_SUBSCRIPTION_STATUSES)),
+          ),
+        );
 
       if (!r) return res.status(404).json({ message: "Charter not found" });
 
@@ -1212,6 +1233,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       if (!cap) {
         return res.status(400).json({ message: "Captain profile required before creating charters" });
+      }
+
+      const subscription = await db.query.subscriptions.findFirst({
+        where: eq(subscriptionsTable.userId, req.session.userId!),
+      });
+
+      if (!subscription || !isActiveSubscriptionStatus(subscription.status)) {
+        return res.status(403).json({
+          message: "An active or trialing subscription is required to create charters",
+        });
       }
 
       // validaciones mínimas
@@ -1328,6 +1359,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Not your charter" });
       }
 
+      const subscription = await db.query.subscriptions.findFirst({
+        where: eq(subscriptionsTable.userId, req.session.userId!),
+      });
+      const subscriptionAllowsListing =
+        !!subscription && isActiveSubscriptionStatus(subscription.status);
+
       const {
         title,
         description,
@@ -1348,7 +1385,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (price !== undefined) updateData.price = String(price);
       if (duration !== undefined) updateData.duration = String(duration);
       if (maxGuests !== undefined) updateData.maxGuests = Number(maxGuests);
-      if (isListed !== undefined) updateData.isListed = Boolean(isListed);
+      if (isListed !== undefined) {
+        if (isListed && !subscriptionAllowsListing) {
+          return res.status(403).json({
+            message: "An active or trialing subscription is required to list charters",
+          });
+        }
+        updateData.isListed = Boolean(isListed) && subscriptionAllowsListing;
+      } else if (!subscriptionAllowsListing) {
+        updateData.isListed = false;
+      }
 
       if (images !== undefined) {
         if (Array.isArray(images)) {
@@ -2718,21 +2764,47 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const existingSub = await db.query.subscriptions.findFirst({
         where: eq(subscriptionsTable.userId, req.session.userId!),
       });
-      
-      if (existingSub && existingSub.status === "active") {
+
+      if (existingSub && isActiveSubscriptionStatus(existingSub.status)) {
         return res.json({ success: true, subscription: existingSub });
       }
 
-      // Crear suscripción en estado "pending" (Do it later option)
-      const subscription = await db.insert(subscriptionsTable).values({
-        userId: req.session.userId!,
-        status: "pending", // "pending" = usuario seleccionó "Do it later"
-        planType: "captain_monthly",
-        trialStartDate: new Date(),
-        trialEndDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30), // 30 days trial
-      }).returning();
+      const now = new Date();
+      const pendingExpiresAt = new Date(now.getTime() + PENDING_SUBSCRIPTION_GRACE_PERIOD_MS);
 
-      res.json({ success: true, subscription: subscription[0] });
+      if (existingSub) {
+        const [updatedSubscription] = await db
+          .update(subscriptionsTable)
+          .set({
+            status: "pending",
+            planType: "captain_monthly",
+            trialStartDate: now,
+            trialEndDate: pendingExpiresAt,
+            currentPeriodStart: now,
+            currentPeriodEnd: pendingExpiresAt,
+            updatedAt: now,
+          })
+          .where(eq(subscriptionsTable.id, existingSub.id))
+          .returning();
+
+        return res.json({ success: true, subscription: updatedSubscription });
+      }
+
+      const [subscription] = await db
+        .insert(subscriptionsTable)
+        .values({
+          userId: req.session.userId!,
+          status: "pending", // Usuario seleccionó "Do it later"
+          planType: "captain_monthly",
+          trialStartDate: now,
+          trialEndDate: pendingExpiresAt,
+          currentPeriodStart: now,
+          currentPeriodEnd: pendingExpiresAt,
+          updatedAt: now,
+        })
+        .returning();
+
+      res.json({ success: true, subscription });
     } catch (error: any) {
       console.error("Create subscription error:", error);
       res.status(500).json({ error: "Failed to create subscription" });
@@ -4122,6 +4194,8 @@ Looking forward to an amazing day on the water! 🛥️`;
     // ==============================
     // HTTP SERVER
     // ==============================
+    scheduleSubscriptionMaintenance();
+
     const httpServer = createServer(app);
     return httpServer;
   }

--- a/server/subscriptionMaintenance.ts
+++ b/server/subscriptionMaintenance.ts
@@ -1,0 +1,120 @@
+import { db } from "./db";
+import {
+  subscriptions as subscriptionsTable,
+  captains as captainsTable,
+  charters as chartersTable,
+} from "@shared/schema";
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
+
+const DEFAULT_INTERVAL_MS = 1000 * 60 * 60; // 1 hour
+let maintenanceTimer: NodeJS.Timeout | undefined;
+
+interface MaintenanceResult {
+  processedSubscriptions: number;
+  affectedCaptains: number;
+  chartersUnlisted: number;
+}
+
+function logMaintenance(message: string, ...optionalParams: unknown[]) {
+  console.log(`[subscription-maintenance] ${message}`, ...optionalParams);
+}
+
+export async function runSubscriptionMaintenance(
+  referenceDate: Date = new Date(),
+): Promise<MaintenanceResult> {
+  const now = referenceDate;
+
+  const subscriptionsNeedingDemotion = await db
+    .select({
+      id: subscriptionsTable.id,
+      userId: subscriptionsTable.userId,
+      status: subscriptionsTable.status,
+    })
+    .from(subscriptionsTable)
+    .where(
+      or(
+        eq(subscriptionsTable.status, "past_due"),
+        and(
+          eq(subscriptionsTable.status, "pending"),
+          or(
+            lt(subscriptionsTable.trialEndDate, now),
+            sql`${subscriptionsTable.trialEndDate} IS NULL`,
+          ),
+        ),
+      ),
+    );
+
+  if (subscriptionsNeedingDemotion.length === 0) {
+    return {
+      processedSubscriptions: 0,
+      affectedCaptains: 0,
+      chartersUnlisted: 0,
+    };
+  }
+
+  const userIds = Array.from(
+    new Set(subscriptionsNeedingDemotion.map((subscription) => subscription.userId)),
+  );
+
+  const captains = await db
+    .select({ id: captainsTable.id })
+    .from(captainsTable)
+    .where(inArray(captainsTable.userId, userIds));
+
+  if (captains.length === 0) {
+    return {
+      processedSubscriptions: subscriptionsNeedingDemotion.length,
+      affectedCaptains: 0,
+      chartersUnlisted: 0,
+    };
+  }
+
+  const captainIds = captains.map((captain) => captain.id);
+
+  const updatedCharters = await db
+    .update(chartersTable)
+    .set({ isListed: false })
+    .where(inArray(chartersTable.captainId, captainIds))
+    .returning({ id: chartersTable.id });
+
+  const result: MaintenanceResult = {
+    processedSubscriptions: subscriptionsNeedingDemotion.length,
+    affectedCaptains: captainIds.length,
+    chartersUnlisted: updatedCharters.length,
+  };
+
+  if (result.chartersUnlisted > 0) {
+    logMaintenance(
+      `Unlisted ${result.chartersUnlisted} charters for ${result.affectedCaptains} captain(s)`,
+    );
+  }
+
+  return result;
+}
+
+export function scheduleSubscriptionMaintenance() {
+  if (process.env.SUBSCRIPTION_MAINTENANCE_DISABLED === "1") {
+    logMaintenance("Scheduler disabled via SUBSCRIPTION_MAINTENANCE_DISABLED");
+    return;
+  }
+
+  if (maintenanceTimer) {
+    return;
+  }
+
+  const requestedInterval = Number(process.env.SUBSCRIPTION_MAINTENANCE_INTERVAL_MS);
+  const intervalMs =
+    Number.isFinite(requestedInterval) && requestedInterval > 0
+      ? requestedInterval
+      : DEFAULT_INTERVAL_MS;
+
+  const run = () => {
+    runSubscriptionMaintenance().catch((error) => {
+      console.error("[subscription-maintenance] Failed to run maintenance job", error);
+    });
+  };
+
+  run();
+  maintenanceTimer = setInterval(run, intervalMs);
+  logMaintenance(`Scheduler started with interval ${intervalMs}ms`);
+}

--- a/server/subscriptionUtils.ts
+++ b/server/subscriptionUtils.ts
@@ -1,0 +1,10 @@
+export const ACTIVE_SUBSCRIPTION_STATUSES = ["active", "trialing"] as const;
+export type ActiveSubscriptionStatus = typeof ACTIVE_SUBSCRIPTION_STATUSES[number];
+
+export function isActiveSubscriptionStatus(
+  status: string | null | undefined,
+): status is ActiveSubscriptionStatus {
+  return status != null && (ACTIVE_SUBSCRIPTION_STATUSES as readonly string[]).includes(status);
+}
+
+export const PENDING_SUBSCRIPTION_GRACE_PERIOD_MS = 1000 * 60 * 60 * 24; // 24 hours


### PR DESCRIPTION
## Summary
- require captains to have an `active` or `trialing` subscription before creating or listing charters and filter marketplace queries to the same statuses
- harden the captain "do it later" subscription endpoint by reusing pending records with a short grace period instead of creating long-lived placeholders
- add a scheduled maintenance job that unlists charters for captains with past-due or expired pending subscriptions and wire it into server start-up

## Testing
- `npm run check` *(fails: existing type errors in client and vite server options)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a68d51c832ab4e688bbc5799c94